### PR TITLE
103 added angular wrapper around cms links using widget blocks

### DIFF
--- a/content/footer-menu.htm
+++ b/content/footer-menu.htm
@@ -1,0 +1,5 @@
+---
+name: footer-menu
+content_type: html
+---
+<p><a href="/company">About Us</a></p><p><a href="/#">History</a></p><p><a href="/#">Return Policy</a></p><p><a href="/blog">Blog</a></p><p><a href="/contact">Contact Us</a></p><p><a href="/products/brands">Brands</a><br></p>

--- a/content/header-menu.htm
+++ b/content/header-menu.htm
@@ -1,0 +1,5 @@
+---
+name: header-menu
+content_type: html
+---
+<p><a href="/">Home</a></p><p><a href="/blog">Blog</a></p><p><a href="/company">Company</a></p><p><a href="/new">Whats New</a><br></p>

--- a/partials/partial-footer.htm
+++ b/partials/partial-footer.htm
@@ -3,14 +3,15 @@
   <div layout="column" layout-align="center center" class="padding-mobile">
     <div layout="row" layout-xs="row" layout-sm="row" layout-wrap layout-align="space-between start" layout-fill class="content-container padding-y-large padding-y-mobile">
 
-      <div layout="column" class="theme-column" flex flex-xs="100" flex-sm="50">
+        <div ng-controller="footerNavCtrl" layout="column" class="theme-column" flex flex-xs="100" flex-sm="50">
         <p class="ls-heading md-caption theme-heading">Company</p>
+        <span class="ng-hide" id="cms-footer">
+            {{ widget_block('footer-menu')}}
+        </span>
         <ul class="theme-list" layout-xs="row" layout-wrap>
-          <li class="md-caption" flex-xs="50"><a href="/about-us">About us</a></li>
-          {% if customer %}<li class="md-caption" flex-xs="50"><a href="/account/orders">Orders</a></li> {% endif %}
-          <li class="md-caption" flex-xs="50"><a href="#">Return Policy</a></li>
-          <li class="md-caption" flex-xs="50"><a href="{{ site_url('/blog') }}">Blog</a></li>
-          <li class="md-caption" flex-xs="50"><a href="/contact-us">Contact us</a></li>
+            <li class="md-caption" flex-xs="50" ng-repeat="nav in footerCmsNav">
+              <a ng-href="[[nav.href]]">[[nav.text]]</a>
+            </li>
         </ul>
       </div>
 

--- a/partials/partial-navbar.htm
+++ b/partials/partial-navbar.htm
@@ -14,11 +14,13 @@
         <img class="nav-home-img" alt="{{ theme.storeTitle }}_logo" src="{{ theme.logoImage.thumbnail('auto', 'auto') }}" />
       </a>
       <div layout="row" layout-align="space-between center" hide-xs hide-sm>
+        <div id="cms-menu" class="ng-hide">
+             {{widget_block('header-menu')}}
+        </div>
+         
         <md-nav-bar nav-bar-aria-label="navigation links" class="md-primary" md-selected-nav-item="currentNavItem">
-            <md-nav-item md-nav-href="/" name="home">Home</md-nav-item>
-            <md-nav-item md-nav-href="/about-us" name="about-us">About Us</md-nav-item>
+            <md-nav-item ng-repeat="nav in cmsNav" md-nav-href="[[nav.href]]" name="home">[[nav.text]]</md-nav-item>
             <md-nav-item md-nav-click="$root.toggleCategoryView();" name="products">Products</md-nav-item>
-            <md-nav-item md-nav-href="/blog" name="blog">Blog</md-nav-item>
             {% if customer %}
               {{ open_form({'data-ajax-handler': 'shop:logout', 'data-validation-message' : ''}) }}
                 <md-button type="submit" value="Log Out" class="md-logout-mobile">Log Out</md-button>
@@ -144,17 +146,17 @@
             </ul>
           </div>
         </div>
-        {% if theme.megaMenuAdTile %}
-          <div layout="column" flex="33" class="featured-ad background-cover padding-medium text-left text-white" style="background-image: url({{ theme.megaMenuAdTileImage.thumbnail(400, 'auto') }});">
-          
-            <h2 class="ls-heading">{{ theme.megaMenuAdTileTitle }}</h2>
-            <div layout="row" layout-align="start center">
-              <md-button href="{{ theme.megaMenuAdTileLink }}" class="md-lowercase md-body-1 no-margin-left">
-                {{ theme.megaMenuAdTileLinkText }}
-              </md-button>
-            </div>
+         {% if theme.megaMenuAdTile %}
+        <div layout="column" flex="33" class="featured-ad background-cover padding-medium text-left text-white" style="background-image: url({{ theme.megaMenuAdTileImage.thumbnail(400, 'auto') }});">
+
+          <h2 class="ls-heading">{{ theme.megaMenuAdTileTitle }}</h2>
+          <div layout="row" layout-align="start center">
+            <md-button href="{{ theme.megaMenuAdTileLink }}" class="md-lowercase md-body-1 no-margin-left">
+              {{ theme.megaMenuAdTileLinkText }}
+            </md-button>
           </div>
-        {% endif %}
+        </div>
+         {% endif %}
       </div>
     </div>
 

--- a/partials/partial-sidenav.htm
+++ b/partials/partial-sidenav.htm
@@ -1,19 +1,11 @@
-<md-sidenav class="md-sidenav-left md-whiteframe-4dp" layout="column" layout-align="space-between start" md-component-id="left">
-  <md-list>
-    <md-list-item ng-click="closeSidenav('left')" ng-href="{{ site_url('/') }}">
-      <p class="ls-heading letter-spacing-2">Home</p>
-    </md-list-item>
-    <md-list-item ng-click="closeSidenav('left')" href="{{ site_url('/company') }}">
-      <p class="ls-heading letter-spacing-2">Company</p>
-    </md-list-item>
-    <md-list-item ng-click="closeSidenav('left')" ng-href="{{ site_url('/products') }}">
-      <p class="ls-heading letter-spacing-2">Products</p>
-    </md-list-item>
-    <md-list-item ng-click="closeSidenav('left')" ng-href="{{ site_url('/blog') }}">
-      <p class="ls-heading letter-spacing-2">Blog</p>
+<md-sidenav  class="md-sidenav-left md-whiteframe-4dp" layout="column" layout-align="space-between start" md-component-id="left">
+  <md-list ng-controller="NavCtrl">
+  
+    <md-list-item ng-click="closeSidenav('left')" ng-repeat="nav in cmsNav" ng-href="[[nav.href]]">
+      <p class="ls-heading letter-spacing-2">[[nav.text]]</p>
     </md-list-item>
   </md-list>
-
+  
   <div style="width:100%;">
     <md-divider></md-divider>
     <md-list>
@@ -32,5 +24,5 @@
         {% endif %}
     </md-list>
   </div>
-
+  
 </md-sidenav>

--- a/resources/js/meyer.js
+++ b/resources/js/meyer.js
@@ -162,6 +162,10 @@ angular.module('lsAngularApp')
       };
       getCurrentNavItem();
 
+      $scope.cmsNav = angular.element('#cms-menu').find('a').map(function(idx, el ){
+          return {text : el.text, href : el.href};
+      });
+
       // call Angular Material's $mdSidenav service
       $scope.openSideNav =  function(navID){ $mdSidenav(navID).open();  };
       $scope.closeSidenav = function(navID){ $mdSidenav(navID).close(); };
@@ -243,8 +247,15 @@ angular.module('lsAngularApp')
       };
 
     });
+    
+    
+angular.module('lsAngularApp')
+  .controller('footerNavCtrl', function ($scope) {
+      $scope.footerCmsNav = angular.element('#cms-footer').find('a').map(function(idx, el ){
+          return {text : el.text, href : el.href};
+      });
 
-
+ });
 /**
  * @ngdoc service
  * @name lsAngularApp.global


### PR DESCRIPTION
Added hidden widget blocks for header and footer content to allow angular to pull values from <a> tags input via the CMS.
These are output in various ng-repeats in header and footer and the names and hrefs applied respectively. 
This allows for the wrapping of links in various angular components. 
For the footer we could potentially add 3 widget blocks, one for each of the 3 sections. 