### PR TITLE
256 options escaping

### DIFF
--- a/pages/product/page-product.htm
+++ b/pages/product/page-product.htm
@@ -117,9 +117,9 @@ url: '/product/:urlName'
                       <md-menu-item>
                         <md-button
                         {% if loop.first %}
-                          ng-init="changeOption('{{option.id}}', '{{key}}' , {{ value }}); viewOption['{{ option.id }}'] = '{{ value }}';"
+                          ng-init="changeOption('{{option.id}}', '{{key}}' , '{{ value }}''); viewOption['{{ option.id }}'] = '{{ value }}';"
                         {% endif %}
-                         ng-click="changeOption('{{option.id}}','{{ key }}' ,{{ value }}); updateSlug('{{ key }}' , '{{ option.id }}' , '{{value}}');; viewOption['{{ option.id }}'] = '{{ value }}'; $root.showLoadingScreen();">
+                         ng-click="changeOption('{{option.id}}','{{ key }}' ,'{{ value }}''); updateSlug('{{ key }}' , '{{ option.id }}' , '{{value}}');; viewOption['{{ option.id }}'] = '{{ value }}'; $root.showLoadingScreen();">
                           <span id="selectable-option-{{key}}">{{ value }}</span>
                         </md-button>
                       </md-menu-item>

--- a/pages/product/page-product.htm
+++ b/pages/product/page-product.htm
@@ -117,9 +117,9 @@ url: '/product/:urlName'
                       <md-menu-item>
                         <md-button
                         {% if loop.first %}
-                          ng-init="changeOption('{{option.id}}', '{{key}}' , '{{ value }}''); viewOption['{{ option.id }}'] = '{{ value }}';"
+                          ng-init="changeOption('{{option.id}}', '{{key}}'); viewOption['{{ option.id }}'] = '{{ value }}';"
                         {% endif %}
-                         ng-click="changeOption('{{option.id}}','{{ key }}' ,'{{ value }}''); updateSlug('{{ key }}' , '{{ option.id }}' , '{{value}}');; viewOption['{{ option.id }}'] = '{{ value }}'; $root.showLoadingScreen();">
+                         ng-click="changeOption('{{option.id}}','{{ key }}'); updateSlug('{{ key }}' , '{{ option.id }}');; viewOption['{{ option.id }}'] = '{{ value }}'; $root.showLoadingScreen();">
                           <span id="selectable-option-{{key}}">{{ value }}</span>
                         </md-button>
                       </md-menu-item>

--- a/pages/product/page-product.htm
+++ b/pages/product/page-product.htm
@@ -117,9 +117,9 @@ url: '/product/:urlName'
                       <md-menu-item>
                         <md-button
                         {% if loop.first %}
-                          ng-init="changeOption('{{option.id}}', '{{key}}'); viewOption['{{ option.id }}'] = '{{ value }}';"
+                          ng-init="changeOption('{{option.id}}', '{{key}}');"
                         {% endif %}
-                         ng-click="changeOption('{{option.id}}','{{ key }}'); updateSlug('{{ key }}' , '{{ option.id }}');; viewOption['{{ option.id }}'] = '{{ value }}'; $root.showLoadingScreen();">
+                         ng-click="changeOption('{{option.id}}','{{ key }}'); updateSlug('{{ key }}' , '{{ option.id }}');; $root.showLoadingScreen();">
                           <span id="selectable-option-{{key}}">{{ value }}</span>
                         </md-button>
                       </md-menu-item>

--- a/partials/shop-cart-items.htm
+++ b/partials/shop-cart-items.htm
@@ -30,7 +30,7 @@ description: 'Cart item list.'
           {% if item.options %}
             <ul>
               {% for option in item.options %}
-                <li class="md-caption ls-caption">[[ '{{ option.value }}' | capitalize ]]</li>
+                <li class="md-caption ls-caption">{{ option.value|upper }}</li>
               {% endfor %}
             </ul>
           {% endif %}
@@ -38,7 +38,7 @@ description: 'Cart item list.'
           {% if item.extras %}
             <ul>
               {% for extra in item.extras %}
-                <li class="md-caption ls-caption">+ [[ '{{ extra.name }}' | capitalize ]] ({{ extra.base_price | currency }})</li>
+                <li class="md-caption ls-caption">+ {{ extra.name|upper }} ({{ extra.base_price | currency }})</li>
               {% endfor %}
             </ul>
           {% endif %}

--- a/partials/shop-checkout-billing.htm
+++ b/partials/shop-checkout-billing.htm
@@ -63,9 +63,11 @@ description: '3 page checkout billing info'
   </md-input-container>
 </div>
 
-<div class="validation-row">
-    <input name="billingInfo[countryId]" ng-model="billing.country" class="input-hidden"  type="text">
-    <span class="error"></span>
+<div class="validation-row" layout="row">
+    <input flex name="billingInfo[countryId]" ng-model="billing.country" class="input-hidden" type="text">
+    <span flex class="error"></span>
+    <input flex name="billingInfo[stateId]" ng-model="billing.state" class="input-hidden"  type="text">
+    <span flex class="error"></span>
 </div>
 
 <div layout="row">

--- a/partials/shop-checkout-cart.htm
+++ b/partials/shop-checkout-cart.htm
@@ -23,7 +23,7 @@ description: '3 page checkout cart items and totals.'
             {% if item.options %}
             <ul>
               {% for option in item.options %}
-                <li class="md-caption ls-caption">[[ '{{ option.value }}' | capitalize ]]</li>
+                <li class="md-caption ls-caption">{{ option.value|upper }}</li>
               {% endfor %}
             </ul>
             {% endif %}
@@ -31,7 +31,7 @@ description: '3 page checkout cart items and totals.'
             {% if item.extras %}
             <ul>
               {% for extra in item.extras %}
-                <li class="md-caption ls-caption">+ [[ '{{ extra.name }}' | capitalize ]] ({{ extra.base_price | currency }})</li>
+                <li class="md-caption ls-caption">+ {{ extra.name|upper }} ({{ extra.base_price | currency }})</li>
               {% endfor %}
             </ul>
             {% endif %}

--- a/partials/shop-checkout-shipping.htm
+++ b/partials/shop-checkout-shipping.htm
@@ -66,9 +66,11 @@ description: '3 page checkout shipping info.'
   </md-input-container>
 </div>
 
-<div class="validation-row">
-    <input name="shippingInfo[countryId]" ng-model="shipping.country" class="input-hidden" type="text">
-    <span class="error"></span>
+<div class="validation-row" layout="row">
+    <input flex name="shippingInfo[countryId]" ng-model="shipping.country" class="input-hidden" type="text">
+    <span flex class="error"></span>
+    <input flex name="shippingInfo[stateId]" ng-model="shipping.state" class="input-hidden"  type="text">
+    <span flex class="error"></span>
 </div>
 
 <div layout="row">

--- a/resources/js/meyer.js
+++ b/resources/js/meyer.js
@@ -967,19 +967,26 @@ angular.module('lsAngularApp')
     };
     
 
-    $scope.updateSlug = function(key, id){
+    $scope.updateSlug = function(value, key){
         
         var baseProductUrl = $window.location.href.split("?")[0];
         var optionString = "";
         var optionCount = 0;
-
         angular.forEach($scope.options, function(v, k, context){
             optionCount++;
-            optionString += 'options['+k+']='+ v;
+            if (k == key) {
+                optionString += 'options['+key+']='+ value;
+            } else {
+                optionString += 'options['+k+']='+ v;
+            }
+            
             if (optionCount < Object.keys(context).length) {
                 optionString += '&';
             }
         });
+        $timeout(function(){
+             $window.location.href = baseProductUrl + '?' + optionString;
+        },100);
     }
     
     angular.forEach(reviews, function(review, index){

--- a/resources/js/meyer.js
+++ b/resources/js/meyer.js
@@ -938,7 +938,7 @@ angular.module('lsAngularApp')
     
     $scope.options = {};
     
-    $scope.changeOption = function(id , key , value){
+    $scope.changeOption = function(id , key){
      var decodedOptions = [];
      var queryString = location.search.substr(1).split('&');
  
@@ -967,7 +967,7 @@ angular.module('lsAngularApp')
     };
     
 
-    $scope.updateSlug = function(key, id, value){
+    $scope.updateSlug = function(key, id){
         
         var baseProductUrl = $window.location.href.split("?")[0];
         var optionString = "";

--- a/resources/js/meyer.js
+++ b/resources/js/meyer.js
@@ -971,13 +971,15 @@ angular.module('lsAngularApp')
         
         var baseProductUrl = $window.location.href.split("?")[0];
         var optionString = "";
+        var optionCount = 0;
 
         angular.forEach($scope.options, function(v, k, context){
-        optionString+='options['+id+']='+ key;
-        })
-        $timeout(function(){
-             $window.location.href = baseProductUrl + '?'+ optionString;
-        },100);
+            optionCount++;
+            optionString += 'options['+k+']='+ v;
+            if (optionCount < Object.keys(context).length) {
+                optionString += '&';
+            }
+        });
     }
     
     angular.forEach(reviews, function(review, index){

--- a/resources/js/meyer.js
+++ b/resources/js/meyer.js
@@ -947,7 +947,7 @@ angular.module('lsAngularApp')
     
             angular.forEach(queryString, function(arr, idx){
                var urlParam = arr.substr(0,arr.indexOf('='))
-               var urlParamIndex = urlParam.match(/\d/g).join();
+               var urlParamIndex = urlParam.match(/\d+/g).join();
                var paramVal = getUrlParameter(urlParam);
                decodedOptions.push([urlParamIndex , paramVal, value]);
             });


### PR DESCRIPTION
#256 

**Fixes**
* Options now work when there is 2+ options on a product
* The URL now handles 2+ options
* Removed some unnecessary twig to angular param passing (fixed multiple escaping issues)
* Fixes error which is originally showed in #256. However another error still shows up, look below. This error does not break the theme, but I believe it slows loading down a bit. It only occurs when `/`,`'` or `"` is in an option value.
* Added error msg for missing state during checkout


Still issues with `/` in option value. The option will work fine, however I get a syntax error in the minified vendor code:
![screen shot 2017-08-24 at 12 52 58 pm](https://user-images.githubusercontent.com/14959054/29685750-42ce5dea-88cb-11e7-8571-e19c8f00c208.png)
