### PR TITLE
Aligned receipt page

### DIFF
--- a/pages/404/page-404.htm
+++ b/pages/404/page-404.htm
@@ -11,13 +11,13 @@ url: /404
 
 <div layout="column" layout-align="center center" class="bg-white">
     
-    <div layout="row">
+    <div layout="row" class="padding-y-medium">
 	    <h1>{{ page.title }}</h1>
 	</div>
 	 <div layout="row">
 	    <h2>Uh Oh! The page was not found!</h2>
 	</div>
-	<div layout="row">
+	<div layout="row" class="padding-y-medium">
 	    <p>Try heading back to the <a class="blue" href="/">homepage</a> to see if you can find what you are looking for from there.</p>
     </div>
 </div>

--- a/pages/product/page-product.htm
+++ b/pages/product/page-product.htm
@@ -91,12 +91,15 @@ url: '/product/:urlName'
               </p>
 
               {% if product.productAttributes %}
-              <div layout="row" layout-xs="column" class="padding-y-small" style="display: table;">
+              <div layout="row" layout-xs="column" class="padding-y-small margin-bottom-small" style="display: table;">
+                	<p class="ls-subheading ls-caption">
+                		Product Specs:
+                	</p>
                 <table>
                   {% for attr in product.productAttributes %}
                   <tr>
-                    <td class="ls-caption float-right">{{ attr.name }}:</td>
-                    <td class="ls-caption md-caption padding-x-small">{{ attr.value }}</td>
+                    <td class="ls-caption">{{ attr.name }}:</td>
+                    <td><span class="ls-caption padding-x-small">{{ attr.value }}</span></td>
                   </tr>
                   {% endfor %}
                 </table>

--- a/pages/receipt/page-receipt.htm
+++ b/pages/receipt/page-receipt.htm
@@ -47,14 +47,14 @@ url: '/receipt/:paymenthash'
            {% endif %}
       
         
-        <div layout="row">
+        <div layout="row" layout-align="center center">
           <md-button class="ls-button md-button-outline  opacity-50 no-margin" ng-href="{{ site_url('products') }}">Continue shopping</md-button>
         </div>
-      </div>
     {% else %}
+    </div>
     <div layout="column" layout-align="center center">
       <h2 class="ls-heading padding-y-medium">No receipt found.</h2>
-      <md-button class="ls-button  no-margin" ng-href="{{ site_url('products') }}">
+      <md-button class="ls-button no-margin" ng-href="{{ site_url('products') }}">
         Continue shopping
       </md-button>
     </div>

--- a/partials/shop-invoiceitems.htm
+++ b/partials/shop-invoiceitems.htm
@@ -25,7 +25,7 @@ description: 'Item list for receipt page and order page.'
           <strong hide show-xs>unit price: </strong><i>{% if item.product.onSale() %}<s class="discount">{{ item.product.fullPrice()|currency }}</s>{% endif %} {{ item.original_price|currency }}</i>
         </td>
         <td class="padding-x-small text-center" colspan="2">
-          <strong hide show-xs>total: </strong><i>{{ item.total()|currency }}</i>
+          <strong hide show-xs>Total: </strong><i>{{ item.total()|currency }}</i>
         </td>
       </tr>
   

--- a/partials/shop-invoicetotals.htm
+++ b/partials/shop-invoicetotals.htm
@@ -19,27 +19,35 @@ description: 'Totals for receipt page and order page.'
     {% set discount = invoice.total_discount %}
     {% set itemTotalNoTax = itemTotalNoTax %}
     {% if itemTotalNoTax > 0 %}
+    	<div class="text-right">
         <md-list-item>
          <p><strong>Item Totals:</strong> <i>{{ itemTotalNoTax |currency }}</i></p>
         </md-list-item>
+    	</div>
     {% endif %}
     {% if invoice.total_shipping_quote > 0 %}
-         <md-list-item>
-            <p><strong>Shipping:</strong> <i>{{ invoice.total_shipping_quote|currency }}</i></p>
-         </md-list-item>
+    		<div class="text-right">
+	         <md-list-item>
+	            <p><strong>Shipping:</strong> <i>{{ invoice.total_shipping_quote|currency }}</i></p>
+	         </md-list-item>
+    		</div>
     {% endif %}
     {% if invoice.tax_total > 0 %}
-        <md-list-item>
-            <p><strong>Tax:</strong> <i>{{ invoice.tax_total|currency }}</i></p>
-        </md-list-item>
+    		<div class="text-right">
+	        <md-list-item>
+	            <p><strong>Tax:</strong> <i>{{ invoice.tax_total|currency }}</i></p>
+	        </md-list-item>
+    		</div>
     {% endif %}
     {% if discount > 0 %}
-         <md-list-item>
-            <p><strong>Total Discount:</strong> <i class="discount"> - {{ discount|currency }}</i></p>
-         </md-list-item>
+    		<div class="text-right">
+	         <md-list-item>
+	            <p><strong>Total Discount:</strong> <i class="discount"> - {{ discount|currency }}</i></p>
+	         </md-list-item>
+    		</div>
     {% endif %}
-        <md-list-item>
-            <h3 class="ls-heading letter-spacing-2 padding-y-medium" layout-align="left center"><strong>Total:</strong>  <i>{{ invoice.total|currency }}</i></h3>
-         </md-list-item>
+    		<div class="text-right">
+            <h3 class="ls-heading letter-spacing-2 padding-y-medium padding-x-small" layout-align="right center"><strong>Total:</strong>  <i>{{ invoice.total|currency }}</i></h3>
+    		</div>
      </md-list>
 </div>

--- a/theme.yaml
+++ b/theme.yaml
@@ -12,7 +12,7 @@ customFields:
     megaMenuAdTile: { type: checkbox, title: 'Show featured ad tile in products dropdown menu', default: '1' }
     featuredAdPanel: { type: checkbox, title: 'Show featured ad panel on the home page', default: '1' }
     showUpsellCrossSell: { type: checkbox, title: 'Show upsell or Cross sell Items in the cart', default: '1' }
-    faviconImage: { type: image, title: 'Favicon Image', default: '', comment: 'Upload your favicon! Recommended dimmensions of 16px by 16px. You must use a .png file.' }
+    faviconImage: { type: image, title: 'Favicon Image', default: '@images/favicon.png', comment: 'Upload your favicon! Recommended dimmensions of 16px by 16px. You must use a .png file.' }
     logoImage: { type: image, title: 'Logo Image', default: '@images/meyer-logo.png', comment: 'Upload your logo! Recommended height of 80px.' }
     logoImageWhite: { type: image, title: 'Logo Image - white version', default: '@images/meyer-logo-white.png', comment: 'Upload your logo, but in white! Recommended height of 80px.' }
     bannerImage: { type: image, title: 'Banner Image', default: '@images/meyer-hero.jpg', comment: 'Upload your own homepage banner! Recommended dimensions of 1920px by 1080px.' }
@@ -26,7 +26,6 @@ customFields:
     headerBackgroundColor: { type: color, title: 'Header/footer background color', default: '#FFFFFF', comment: 'Color used for the header and footer background.' }
     headerTextColor: { type: color, title: 'Header/footer text color', default: '#212121', comment: 'Color used for all header and footer text.' }
     storeTitle: { type: text, title: 'Title of your Store', default: Meyer }
-    bannerTitleText: { type: text, title: 'Banner Title Text', default: Meyer, comment: 'Text used for the homepage banner title.' }
     bannerSentenceText: { type: text, title: 'Banner Sentence Text', default: 'A responsive LemonStand theme', comment: 'Text used for the homepage banner sentence.' }
     signUpText: { type: text, title: 'Newsletter sign up text', default: 'Sign up for our newsletter.', comment: 'An incentive for people to sign up for your newsletter.' }
     storeReturnPolicy: { type: text, title: 'Store return policy', default: 'Up to 30 days from purchase.  Must not be opened or damaged.', comment: 'Let people know if they can return items after purchase.' }
@@ -37,7 +36,6 @@ customFields:
     featuredAdPanelLinkText: { type: text, title: 'Featured ad link text for the home page', default: 'View collection', comment: 'Eg. "View collection"' }
     featuredAdPanelTitle: { type: text, title: 'Title for the featured ad panel on the home page', default: 'Summer sale', comment: 'What are you trying to advertise?' }
     featuredAdPanelText: { type: text, title: 'Description for the featured ad panel on the home page', default: 'Check out this awesome sale!', comment: 'Let people know why they would want to click the link.' }
-    storeLatLng: { type: text, title: 'Google Maps Latitude and Longitude', default: '49.2838684,-123.1146013' }
     pinterestUrl: { type: text, title: 'Pinterest URL', default: 'http://pinterest.com/lemonstand', comment: 'If you don''t have Pinterest enter "none"' }
     facebookUrl: { type: text, title: 'Facebook URL', default: 'http://facebook.com/lemonstand', comment: 'If you don''t have Facebook enter "none"' }
     twitterUrl: { type: text, title: 'Twitter username (without @)', default: lemonstand, comment: 'If you don''t have Twitter enter "none"' }
@@ -47,7 +45,6 @@ customFields:
     headingFont: { type: dropdown, title: 'Heading font', comment: 'Used for headings.', default: 'Montserrat, sans-serif', options: { 'Montserrat, sans-serif': Montserrat, 'Roboto, sans-serif': Roboto, 'Open Sans, sans-serif': 'Open Sans', 'PT Serif, serif': 'PT Serif', 'Alex Brush, cursive': 'Alex Brush', 'Merriweather, serif': Merriweather, 'Oswald, sans-serif': Oswald, 'Lato, sans-serif': Lato, 'Droid Sans, sans-serif': 'Droid Sans', 'Source Sans Pro, sans-serif': 'Source Sans Pro', 'Arvo, serif': Arvo, 'Arial, sans-serif': Arial, 'Georgia, serif': Georgia } }
     bodyFont: { type: dropdown, title: 'Body font', comment: 'Used for all other text.', default: 'Roboto, sans-serif', options: { 'Montserrat, sans-serif': Montserrat, 'Roboto, sans-serif': Roboto, 'Open Sans, sans-serif': 'Open Sans', 'PT Serif, serif': 'PT Serif', 'Alex Brush, cursive': 'Alex Brush', 'Merriweather, serif': Merriweather, 'Oswald, sans-serif': Oswald, 'Lato, sans-serif': Lato, 'Droid Sans, sans-serif': 'Droid Sans', 'Source Sans Pro, sans-serif': 'Source Sans Pro', 'Arvo, serif': Arvo, 'Arial, sans-serif': Arial, 'Georgia, serif': Georgia } }
     buttonShape: { type: dropdown, title: 'Button shape', comment: 'The default button shape.', default: 0px, options: { 0px: Sharp, 3px: 'Slightly rounded', 25px: Pill } }
-    bannerButtonStyle: { type: dropdown, title: 'Banner button style', comment: 'The style for the button on the hero banner.', default: solid, options: { solid: Solid, outline: 'Empty, with outline' } }
     productTileOverlay: { type: dropdown, title: 'Product tile text background', comment: 'The background behind text on each product tile.', default: 'rgba(255,255,255,0.75)', options: { transparent: None, 'rgba(0,0,0,0.5)': 'Transparent black', 'rgba(255,255,255,0.75)': 'Transparent white' } }
     categoryTileOverlay: { type: dropdown, title: 'Category tile text background', comment: 'The background behind text on each category tile on homepage.', default: 'rgba(0,0,0,0.5)', options: { transparent: None, 'rgba(0,0,0,0.5)': 'Transparent black', 'rgba(255,255,255,0.75)': 'Transparent white' } }
 ---


### PR DESCRIPTION
Aligned receipt items:

<img width="869" alt="screen shot 2017-11-18 at 6 44 56 pm" src="https://user-images.githubusercontent.com/6082087/32985819-ce330c4c-cc90-11e7-9c69-2a79e2c1aca5.png">

And deleted a couple of settings that weren't doing anything from `theme.yaml`: Banner button and google coords. 

Also added default favicon for meyer theme. 