### PR TITLE
Made category page accept subcategories.

### DIFF
--- a/pages/api-category/page-api-category.htm
+++ b/pages/api-category/page-api-category.htm
@@ -5,7 +5,7 @@ template: json-api
 protocol: all
 published: true
 name: 'Category API'
-url: '/api/categories/:urlName'
+url: '/api/categories/:urlName@'
 ---
 {
   "name": {{ category.name | json_encode() | raw }},


### PR DESCRIPTION
Old code in Meyer had same issue with URL structure.  Old meyer didn't rely on this URL structure as Meyer did all the filtering on the client end instead.

Test store: https://meyer-staging.lemonstand.com/

Test case:  https://meyer-staging.lemonstand.com/products#/womens?sale=false&price=25.  Try to filter using any of the filter options.  This should fix filtering for any sub categories.

**Note there appears to be some sort of caching issue potentially with lemon sync maybe?  As this was not replicated when we did our initial fixes.  Please see comments made here by @rudy-sasquatchstudio https://github.com/lemonstand/lscloud-theme-meyer/issues/270.  This was only replicated after having to upload a fresh theme copy to store.  